### PR TITLE
Fix build error for audio_amplifier.c

### DIFF
--- a/include/hardware/audio_amplifier.h
+++ b/include/hardware/audio_amplifier.h
@@ -113,6 +113,18 @@ typedef struct amplifier_device {
      */
     int (*set_parameters)(struct amplifier_device *device,
         struct str_parms *parms);
+
+    /**
+     * set/get output stream parameters.
+     */
+    int (*out_set_parameters)(struct amplifier_device *device,
+        struct str_parms *parms);
+
+    /**
+     * set/get input stream parameters.
+     */
+    int (*in_set_parameters)(struct amplifier_device *device,
+        struct str_parms *parms);
 } amplifier_device_t;
 
 typedef struct amplifier_module {


### PR DESCRIPTION
This fixes the build error that we get while building in
audio_amplifier.o hardware/qcom-caf/msm8998/audio/hal/audio_extn/audio_amplifier.c"
hardware/qcom-caf/msm8998/audio/hal/audio_extn/audio_amplifier.c:140: 27: error: no member named "out_set_parameters' in 'struct amplifier_device'; did you mean 'set_parameters'?
